### PR TITLE
hot-fix: gitsigns not load config

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -280,7 +280,12 @@ packer.startup({
 
     -------------------------------------------------------
     -- git
-    use({ "lewis6991/gitsigns.nvim" })
+    use({
+      "lewis6991/gitsigns.nvim",
+      config = function()
+        require("plugin-config.gitsigns")
+      end,
+    })
     -- vimspector
     use({
       "puremourning/vimspector",


### PR DESCRIPTION
gitsigns插件没有加载它的配置文件